### PR TITLE
Coverage tracking and graphical representation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Custom for Visual Studio
+*.cs     diff=csharp
+
+# Standard to msysgit
+*.doc	 diff=astextplain
+*.DOC	 diff=astextplain
+*.docx diff=astextplain
+*.DOCX diff=astextplain
+*.dot  diff=astextplain
+*.DOT  diff=astextplain
+*.pdf  diff=astextplain
+*.PDF	 diff=astextplain
+*.rtf	 diff=astextplain
+*.RTF	 diff=astextplain

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,47 @@
+# Windows image file caches
+Thumbs.db
+ehthumbs.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# =========================
+# Operating System Files
+# =========================
+
+# OSX
+# =========================
+
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk

--- a/src/utcov/Data.cls
+++ b/src/utcov/Data.cls
@@ -1,0 +1,88 @@
+Class utcov.Data Extends %Persistent
+{
+
+Index CoverageDataPK On (TestIndex, TestClass, TestMethod, RoutineName, RoutineType, LineNumber) [ Data = (LineText, LineCovered, Executable), Unique ];
+
+Property TestIndex As %String;
+
+Property TestClass As %String(COLLATION = "SQLUPPER(125)", MAXLEN = 255);
+
+Property TestMethod As %String(COLLATION = "SQLUPPER(125)", MAXLEN = 255);
+
+Property RoutineName As %String(COLLATION = "SQLUPPER(125)", MAXLEN = 255);
+
+Property RoutineType As %String(MAXLEN = 3);
+
+Property LineNumber As %Integer;
+
+Property LineText As %String(MAXLEN = "");
+
+Property LineCovered As %Boolean;
+
+Property Executable As %Boolean [ InitialExpression = 0 ];
+
+Index TestIndex On TestIndex [ Type = bitmap ];
+
+Index TestClass On TestClass [ Type = bitmap ];
+
+Index TestMethod On TestMethod [ Type = bitmap ];
+
+Index RoutineName On RoutineName [ Type = bitmap ];
+
+Index RoutineType On RoutineType [ Type = bitmap ];
+
+Index LineNumber On LineNumber [ Type = bitmap ];
+
+Index LineCovered On LineCovered [ Type = bitmap ];
+
+Index Executable On Executable [ Type = bitmap ];
+
+/// Supports Coverage.Utils:ConvertToClassCoverage
+Index TestedRoutine On (TestIndex, RoutineType, RoutineName As Exact, LineNumber);
+
+/// Supports Coverage.Utils:ConvertToClassCoverage
+Index CoveredIntLines On (TestIndex, RoutineType, RoutineName, LineNumber, LineCovered, TestClass, TestMethod);
+
+Storage Default
+{
+<Data name="DataDefaultData">
+<Value name="1">
+<Value>%%CLASSNAME</Value>
+</Value>
+<Value name="2">
+<Value>TestIndex</Value>
+</Value>
+<Value name="3">
+<Value>TestClass</Value>
+</Value>
+<Value name="4">
+<Value>TestMethod</Value>
+</Value>
+<Value name="5">
+<Value>RoutineName</Value>
+</Value>
+<Value name="6">
+<Value>RoutineType</Value>
+</Value>
+<Value name="7">
+<Value>LineNumber</Value>
+</Value>
+<Value name="8">
+<Value>LineText</Value>
+</Value>
+<Value name="9">
+<Value>LineCovered</Value>
+</Value>
+<Value name="10">
+<Value>Executable</Value>
+</Value>
+</Data>
+<DataLocation>^Coverage.DataD</DataLocation>
+<DefaultData>DataDefaultData</DefaultData>
+<IdLocation>^Coverage.DataD</IdLocation>
+<IndexLocation>^Coverage.DataI</IndexLocation>
+<StreamLocation>^Coverage.DataS</StreamLocation>
+<Type>%Library.CacheStorage</Type>
+}
+
+}

--- a/src/utcov/Manager.cls
+++ b/src/utcov/Manager.cls
@@ -12,7 +12,7 @@ Property CurrentTestMethod As %String(MAXLEN = 255) [ Internal, Private ];
 
 /// Invoked externally to run all unit tests.
 /// Presupposes that unit tests have been included in the build.
-ClassMethod RunAllTests(pPackage As %String = "", pLogFile As %String = "", pUnitTestClasses As %List = "", pCoverageClasses As %List = "", pCoverageRoutines As %List = "") As %Status
+ClassMethod RunAllTests(pPackage As %String = "", pLogFile As %String = "", pUnitTestClasses As %List = "", pCoverageClasses As %List = "", pCoverageRoutines As %List = "", pCoverageLevel As %Integer = 0) As %Status
 {
 	#dim tUnitTestManager As utcov.Manager
 	Set tSuccess = 1
@@ -32,6 +32,7 @@ ClassMethod RunAllTests(pPackage As %String = "", pLogFile As %String = "", pUni
 		Set tUnitTestManager = ..%New()
 		Set tUnitTestManager.Display = "log,error"
 		Do tUnitTestManager.SetCoverageTargets(pCoverageClasses,pCoverageRoutines)
+		Set tUnitTestManager.CoverageDetail = pCoverageLevel
 		Set tStmt = ##class(%SQL.Statement).%New()
 		$$$ThrowOnError(tStmt.%PrepareClassQuery("%Dictionary.ClassDefinition","SubclassOf"))
 		Set tRes = tStmt.%Execute("%UnitTest.TestCase",pPackage)

--- a/src/utcov/Manager.cls
+++ b/src/utcov/Manager.cls
@@ -1,0 +1,191 @@
+Class utcov.Manager Extends %UnitTest.Manager
+{
+
+/// Not yet respected - level to aggregate coverage data.
+Property CoverageDetail As %String(DISPLAYLIST = ",Overall,Class,Method", VALUELIST = ",0,1,2") [ InitialExpression = 2 ];
+
+Property CoverageTargets As %List [ Internal, Private ];
+
+Property CurrentTestClass As %String(MAXLEN = 255) [ Internal, Private ];
+
+Property CurrentTestMethod As %String(MAXLEN = 255) [ Internal, Private ];
+
+/// Invoked externally to run all unit tests.
+/// Presupposes that unit tests have been included in the build.
+ClassMethod RunAllTests(pPackage As %String = "", pLogFile As %String = "", pUnitTestClasses As %List = "", pCoverageClasses As %List = "", pCoverageRoutines As %List = "") As %Status
+{
+	#dim tUnitTestManager As utcov.Manager
+	Set tSuccess = 1
+	Try {
+		Set tLogFileOpen = 0
+		Set tOldIO = $io
+		If (pLogFile '= "") {
+			Open pLogFile:"WNS":10
+			Set tLogFileOpen = 1
+			Use pLogFile
+		}
+		
+		Write "*** Unit tests starting at ",$zdt($h,3)," ***",!
+	
+		Set tBegin = $zh
+	
+		Set tUnitTestManager = ..%New()
+		Set tUnitTestManager.Display = "log,error"
+		Do tUnitTestManager.SetCoverageTargets(pCoverageClasses,pCoverageRoutines)
+		Set tStmt = ##class(%SQL.Statement).%New()
+		$$$ThrowOnError(tStmt.%PrepareClassQuery("%Dictionary.ClassDefinition","SubclassOf"))
+		Set tRes = tStmt.%Execute("%UnitTest.TestCase",pPackage)
+		While tRes.%Next(.tSC) {
+			$$$ThrowOnError(tSC)
+			Do tUnitTestManager.RunUnitTestClass(tRes.%Get("Name"))
+		}
+		$$$ThrowOnError(tSC)
+	
+		If $IsObject(tUnitTestManager) {
+			Do tUnitTestManager.SaveResult($zh-tBegin)
+			Do tUnitTestManager.PrintURL()
+			
+			Set (tFailed,tPassed,tSkipped) = 0
+			&sql(select sum(case when c.Status = 0 then 1 else 0 end) as failed,
+						sum(case when c.Status = 1 then 1 else 0 end) as passed,
+						sum(case when c.Status = 2 then 1 else 0 end) as skipped
+						into :tFailed, :tPassed, :tSkipped
+				   from %UnitTest_Result.TestSuite s
+				   join %UnitTest_Result.TestCase c
+				     on s.Id = c.TestSuite
+				  where s.TestInstance = :tUnitTestManager.LogIndex)
+
+			If (tFailed '= 0) {
+				Set tSuccess = 0
+			}
+		} Else {
+			Write "No unit tests found matching package: ",pPackage,!
+		}
+	} Catch anyException {
+		Set tSuccess = 0
+		Write anyException.DisplayString(),!
+	}
+	Write !,!,"Test cases: ",tPassed," passed, ",tSkipped," skipped, ",tFailed," failed",!
+	If 'tSuccess {
+		Write !,"ERROR(S) OCCURRED."
+	}
+	Use tOldIO
+	Close:tLogFileOpen pLogFile
+	Quit $Select(tSuccess:1,1:$$$ERROR($$$GeneralError,"One or more errors occurred in unit tests."))
+}
+
+Method RunUnitTestClass(pClassName As %String)
+{
+	Set tTestSuite = $Piece(pClassName,".",1,$length(pClassName,".")-1)
+	Set qspec = "/noload/nodelete"
+	Set tSC = $$$qualifierParseAlterDefault("UnitTest","/keepsource",.qspec,.qstruct)
+	Do ..RunOneTestSuite("",$Replace(tTestSuite,".","/"),tTestSuite_":"_pClassName,.qstruct)
+}
+
+Method SetCoverageTargets(pClasses As %List = "", pRoutines As %List = "")
+{
+	Set tList = "", tPtr = 0
+	While $ListNext(pClasses,tPtr,tClass) {
+		// Use a wildcard to include all .int files associated with the class.
+		Set tList = tList_$ListBuild(tClass_".*") 
+	}
+	While $ListNext(pRoutines,tPtr,tRoutine) {
+		Set tList = tList_$ListBuild(tRoutine)
+	}
+	Set ..CoverageTargets = tList
+}
+
+Method StartCoverageTracking(pTestClass As %String, pTestMethod As %String) As %Status
+{
+	Set tSC = $$$OK
+	Try {
+		If (..CoverageTargets '= "") {
+			Set ..CurrentTestClass = pTestClass
+			Set ..CurrentTestMethod = pTestMethod
+			$$$ThrowOnError(##class(%Monitor.System.LineByLine).Start(..CoverageTargets,$ListBuild("RtnLine"),$ListBuild($Job)))
+		}
+	} Catch anyException { 
+		Set tSC = anyException.AsStatus()
+	}
+	Quit tSC
+}
+
+Method EndCoverageTracking() As %Status
+{
+	Set tSC = $$$OK
+	Try {
+		If (..CoverageTargets '= "") {
+			// Pause the monitor.
+			$$$ThrowOnError(##class(%Monitor.System.LineByLine).Pause())
+			
+			Set tTextIndex = "TEMP-"_..TempLogIndex
+			Set tTestClass = ..CurrentTestClass
+			Set tTestMethod = ..CurrentTestMethod
+			
+			Set tRtnCount = ##class(%Monitor.System.LineByLine).GetRoutineCount()
+			For i=1:1:tRtnCount {
+				Set tRtnName = ##class(%Monitor.System.LineByLine).GetRoutineName(i)
+				// Capture line-by-line monitor results to Coverage.Data, possibly updating existing data
+				&sql(insert or update into utcov.Data
+					(TestIndex, TestClass, TestMethod,
+						RoutineName, RoutineType,
+						LineText, LineNumber, LineCovered)
+					select :tTextIndex, :tTestClass, :tTestMethod,
+						:tRtnName, 'int',
+						utcov.Utils_GetLineText(:tRtnName,'int',LineNumber), LineNumber,
+						CASE R.LineCovered WHEN 1 THEN 1 ELSE 
+							NVL((select MAX(LineCovered)
+								from utcov.Data D
+								where D.TestIndex = :tTestIndex
+									and D.TestClass = :tTestClass
+									and D.TestMethod = :tTestMethod
+									and D.RoutineName = :tRtnName
+									and D.RoutineType = 'int'
+									and R.LineNumber = D.LineNumber),0)
+						END
+					from utcov.Utils_Result(:tRtnName) R
+				)
+				If (SQLCODE < 0) {
+					Throw ##class(%Exception.SQL).CreateFromSQLCODE(SQLCODE,$g(%msg))
+				}
+			}
+			
+			// Stop the monitor.
+			$$$ThrowOnError(##class(%Monitor.System.LineByLine).Stop())
+		}
+	} Catch anyException {
+		// Ensure that the monitor is stopped.
+		Do ##class(%Monitor.System.LineByLine).Stop()
+		Set tSC = anyException.AsStatus()
+	}
+	Quit tSC
+}
+
+Method SaveResult(duration)
+{
+	Do ##super()
+	Set tOldLogIndex = "TEMP-"_..TempLogIndex
+	Set tLogIndex = ..LogIndex
+	&sql(update utcov.Data set TestIndex = :tLogIndex where TestIndex = :tOldLogIndex)
+	
+	Do ##class(utcov.Utils).ConvertToClassCoverage(tLogIndex)
+	
+	Quit
+}
+
+/// Record the end of a test and also return the status of this 
+Method LogStateBegin(testsuite, testcase = "", testmethod = "")
+{
+	Do ##super(testsuite,testcase,testmethod)
+	Do ..StartCoverageTracking($Select(..CoverageDetail>0:testcase,1:""),
+		$Select(..CoverageDetail>1:testmethod,1:""))
+}
+
+/// Record the end of a test and also return the status of this 
+Method LogStateEnd(duration) As %Integer
+{
+	Do ..EndCoverageTracking()
+	Quit ##super(duration)
+}
+
+}

--- a/src/utcov/UI/SimpleResultViewer.cls
+++ b/src/utcov/UI/SimpleResultViewer.cls
@@ -1,0 +1,188 @@
+Class utcov.UI.SimpleResultViewer extends %ZEN.Component.page {
+
+Parameter PAGENAME = "Unit Test Coverage - Simple Results Viewer";
+
+XData Style
+{
+
+<style type="text/css">
+/* From http://codepen.io/elomatreb/pen/hbgxp */
+body {
+  background-color: #eee;
+  color: #555;
+}
+
+/* Modified from pre.coverage */
+.box {
+  background-color: #fff;
+  padding: 0.5em;
+  margin-top: 2em;
+  border-radius: .25em;
+  box-shadow: 0.1em 0.1em 0.5em rgba(0, 0, 0, 0.45);
+}
+
+/* From http://codepen.io/elomatreb/pen/hbgxp */
+pre.coverage {
+  font-family: monospace;
+  background-color: #fff;
+  margin-top: 2em;
+  margin-left: 4em auto;
+  margin-right: 4em auto;
+  padding: 0.5em;
+  border-radius: .25em;
+  box-shadow: 0.1em 0.1em 0.5em rgba(0, 0, 0, 0.45);
+  line-height: 0;
+  counter-reset: line;
+}
+pre.coverage span {
+  display: block;
+  line-height: 1.5rem;
+}
+pre.coverage span:before {
+  counter-increment: line;
+  content: counter(line);
+  display: inline-block;
+  border-right: 1px solid #ddd;
+  padding: 0 .5em;
+  margin-right: .5em;
+  min-width: 3em;
+  color: #888;
+}
+
+/* Classes for display of code coverage */
+pre.coverage span.executable {
+  background-color: #f66;
+}
+
+pre.coverage span.covered {
+  background-color: #6f6;
+}
+
+</style>
+}
+
+XData Contents [ XMLNamespace = "http://www.intersystems.com/zen" ]
+{
+<page xmlns="http://www.intersystems.com/zen">
+
+<vgroup width="80%" align="center">
+<vgroup labelPosition="left" align="left" enclosingClass="box">
+<select id="testIndex" label="Test Index" sql="select distinct TestIndex from utcov.Data" onchange="zenPage.testFilterChanged(zenThis)" />
+<select id="testClass" label="Test Class" sql="select distinct %exact TestClass from utcov.Data where TestIndex = ?" onchange="zenPage.testFilterChanged(zenThis)">
+<parameter value="" />
+</select>
+<select id="testMethod" label="Test Method" sql="select distinct %exact TestMethod from utcov.Data where TestIndex = ? and TestClass = ?" onchange="zenPage.testFilterChanged(zenThis)">
+<parameter value="" />
+<parameter value="" />
+</select>
+
+<spacer height="25px" />
+
+<select id="codeCovered" label = "Code Module"
+	sql="select distinct %exact RoutineName||'.'||RoutineType
+			from utcov.Data d,(select ? as TestIndex, ? as TestClass, ? as TestMethod) params
+			where d.TestIndex = params.TestIndex
+				and (params.TestClass is null or params.TestClass = d.TestClass)
+				and (params.TestMethod is null or params.TestMethod = d.TestMethod)
+			order by DECODE(RoutineType,'cls',1,'mac',2,3)"
+	onchange="zenPage.showCodeCoverage();">
+<parameter value="" />
+<parameter value="" />
+<parameter value="" />
+</select>
+</vgroup>
+
+<altJSONSQLProvider id="coverageDataProvider" 
+	sql="select distinct d.LineText text, MAX(d.LineCovered) covered, d.Executable executable
+			from utcov.Data d,(select ? as TestIndex, ? as TestClass, ? as TestMethod, ? as RoutineName, ? as RoutineType) params
+			where d.TestIndex = params.TestIndex
+				and (params.TestClass is null or params.TestClass = d.TestClass)
+				and (params.TestMethod is null or params.TestMethod = d.TestMethod)
+				and d.RoutineName = params.RoutineName
+				and d.RoutineType = params.RoutineType
+			group by LineNumber
+			order by LineNumber">
+<!--TODO: Find out if there's a better way to identify/use parameters by paramName?-->
+<parameter paramName="1" value="" />
+<parameter paramName="2" value="" />
+<parameter paramName="3" value="" />
+<parameter paramName="4" value="" />
+<parameter paramName="5" value="" />
+</altJSONSQLProvider>
+
+<html id="coverageResults" align="left">
+</html>
+
+</vgroup>
+
+</page>
+}
+
+ClientMethod testFilterChanged(pSrcComponent As %ZEN.Component.select) [ Language = javascript ]
+{
+	if (pSrcComponent.id == 'testIndex') {
+		zen('testClass').parameters[0].value = pSrcComponent.getValue();
+		zen('testMethod').parameters[0].value = pSrcComponent.getValue();
+		zen('codeCovered').parameters[0].value = pSrcComponent.getValue();
+		zen('coverageDataProvider').parameters[1].value = pSrcComponent.getValue();
+	}
+	
+	if (pSrcComponent.id == 'testClass') {
+		zen('testMethod').parameters[1].value = pSrcComponent.getValue();
+		zen('codeCovered').parameters[1].value = pSrcComponent.getValue();
+		zen('coverageDataProvider').parameters[2].value = pSrcComponent.getValue();
+	}
+	
+	if (pSrcComponent.id == 'testMethod') {
+		zen('codeCovered').parameters[2].value = pSrcComponent.getValue();
+		zen('coverageDataProvider').parameters[3].value = pSrcComponent.getValue();
+	}	
+	
+	zen('testClass').refreshContents();
+	zen('testMethod').refreshContents();
+	zen('codeCovered').refreshContents();
+
+	if (zen('codeCovered').getValue() != '') {
+		this.showCodeCoverage();
+	}
+}
+
+ClientMethod showCodeCoverage() [ Language = javascript ]
+{
+	var targetCode = zen('codeCovered').getValue().split('.');
+	var targetType = targetCode.pop();
+	var targetName = targetCode.join('.');
+	zen('coverageDataProvider').parameters[4].value = targetName;
+	zen('coverageDataProvider').parameters[5].value = targetType;
+	zen('coverageDataProvider').reloadContentsAsynch(function() {
+		var code = zen('coverageDataProvider').getContentObject().children;
+		var html = '<pre class="coverage">\r\n';
+		for (var i = 0; i < code.length; i++) {
+			var classes = new Array();
+			if (code[i].covered) classes.push("covered");
+			if (code[i].executable) classes.push("executable");
+			html += '<span class="'+classes.join(' ')+'">'+code[i].text.escapeHTML()+'</span>\r\n';
+		}
+		html += '</pre>';
+		zen('coverageResults').setContent(html);
+	});
+}
+
+Method %OnDrawObjectProperties()
+{
+	//From http://stackoverflow.com/questions/5499078/fastest-method-to-escape-html-tags-as-html-entities
+	&js<
+		String.prototype.escapeHTML = function() {
+		    var tagsToReplace = {
+		        '&': '&amp;',
+		        '<': '&lt;',
+		        '>': '&gt;'
+		    };
+		    return this.replace(/[&<>]/g, function(tag) {
+		        return tagsToReplace[tag] || tag;
+		    });
+		};
+	>
+}
+
+}

--- a/src/utcov/Utils.cls
+++ b/src/utcov/Utils.cls
@@ -1,0 +1,137 @@
+Include %occInclude
+
+Class utcov.Utils
+{
+
+ClassMethod GetLineText(pRoutineName, pRoutineType, pLineNumber) As %String [ SqlProc ]
+{
+	Set tText = "not yet implemented"
+	If (pRoutineType = "int") {
+		Quit $Text(@("+"_pLineNumber_"^"_pRoutineName))
+	}
+	Quit tText
+}
+
+ClassMethod ConvertToClassCoverage(pTestIndex As %String)
+{
+	// Get .int routines
+	Set tRes = ##class(%SQL.Statement).%ExecDirect(,"select distinct %exact RoutineName RoutineName from utcov.Data where TestIndex = ? and RoutineType = 'int'",pTestIndex)
+	While tRes.%Next(.tSC) {
+		$$$ThrowOnError(tSC)
+		Set tRtnName = tRes.%Get("RoutineName")
+		Set tOther = ##class(%Library.RoutineMgr).GetOther(tRtnName,"int",-1)
+		Set tClassName = $Piece(tOther,".",1,*-1)
+		If (tOther '= "") && ($Piece(tOther,".",*) = "CLS") {
+			If '$Data(tVisistedClasses(tOther)) {
+				Kill tDocumentText, tMethodMap
+				$$$ThrowOnError(##class(%Compiler.UDL.TextServices).GetTextAsArray(,tClassName,.tDocumentText))
+				
+				// Clear existing data
+				&sql(delete from utcov.Data where TestIndex = :pTestIndex and RoutineName = :tClassName and RoutineType = 'cls')
+				
+				// Create table with class document's text
+				Set tMethod = "", tInBlockComment = 0
+				Set tDocumentText = $Order(tDocumentText(""),-1)
+				For i=1:1:$Get(tDocumentText) {
+					Set tLine = tDocumentText(i)
+					&sql(insert or update into utcov.Data
+						(TestIndex, TestClass, TestMethod,
+							RoutineName, RoutineType,
+							LineText, LineNumber, LineCovered)
+						select distinct by (NVL(TestClass,''),NVL(TestMethod,'')) :pTestIndex, TestClass, TestMethod,
+							:tClassName, 'cls',
+							:tLine, :i, 0
+						from utcov.Data
+							where TestIndex = :pTestIndex
+								and RoutineType = 'int'
+								and RoutineName = :tRtnName)
+					If (SQLCODE < 0) {
+						Throw ##class(%Exception.SQL).CreateFromSQLCODE(SQLCODE,%msg)
+					}
+					
+					// Extract line offset of method in class
+					Set tStart = $Extract(tLine,1,6)
+					If (tStart = "ClassM") || (tStart = "Method") {
+						Set tMethod = $Piece($Piece(tLine,"(")," ",2)
+						Set tMethodMap(tMethod) = i
+					}
+				}
+				
+				Merge tVisistedClasses(tOther) = tDocumentText
+				Merge tMethodMaps(tOther) = tMethodMap
+			}
+			
+			// Try to map each executed line in the routine back to a line in the class.
+			Set tResLines = ##class(%SQL.Statement).%ExecDirect(,"select distinct LineNumber "_
+					"from utcov.Data "_
+					"where TestIndex = ? "_
+					"	and RoutineType = 'int' "_
+					"	and RoutineName = ? "_
+					"	and LineCovered = 1 ", pTestIndex, tRtnName)
+			While (tResLines.%Next(.tSC)) {
+				$$$ThrowOnError(tSC)
+				Kill tMap
+				$$$ThrowOnError(##class(%Studio.Debugger).SourceLine(tRtnName, tResLines.%Get("LineNumber"), 1, tResLines.%Get("LineNumber"), $Length(..GetLineText(tRtnName,"int",tResLines.%Get("LineNumber"))), $Namespace, .tMap))
+				
+				If $Data(tMap("CLS",1),tData1) && $Data(tMap("CLS",2),tData2) {
+					Set $ListBuild(tClass1,tMethod1,tLine1) = tData1
+					Set $ListBuild(tClass2,tMethod2,tLine2) = tData2
+					If $Data(tMethodMaps(tOther,tMethod1),tMethodOffset) {
+						For tLine = tLine1:1:tLine2 {
+							Set tClassLine = tMethodOffset+1+tLine
+							&sql(update utcov.Data
+								set LineCovered = 1
+								where TestIndex = :pTestIndex
+									and RoutineType = 'cls'
+									and RoutineName = :tClassName
+									and LineNumber = :tClassLine
+									/*and exists (
+										select top 1 1 from utcov.Data OTHER
+										where OTHER.TestIndex = :pTestIndex
+											and OTHER.RoutineType = 'int'
+											and OTHER.RoutineName = :tRtnName
+											and OTHER.LineNumber = :tRes.%Get("LineNumber")
+											and OTHER.LineCovered = 1
+											and OTHER.TestClass = D.TestClass
+											and OTHER.TestMethod = D.TestMethod
+									)*/
+							)
+							If (SQLCODE < 0) {
+								Throw ##class(%Exception.SQL).CreateFromSQLCODE(SQLCODE,%msg)
+							}
+						}
+					}
+				}
+			}
+			$$$ThrowOnError(tSC)
+		}
+	}
+	$$$ThrowOnError(tSC)
+}
+
+Query Result(pRoutine As %String) As %Query(ROWSPEC = "LineNumber:%Integer,LineCovered:%Boolean") [ SqlProc ]
+{
+}
+
+ClassMethod ResultExecute(ByRef qHandle As %Binary, pRoutine As %String) As %Status
+{
+	Quit ##class(%Monitor.System.LineByLine).ResultExecute(.qHandle,pRoutine)
+}
+
+ClassMethod ResultFetch(ByRef qHandle As %Binary, ByRef Row As %List, ByRef AtEnd As %Integer = 0) As %Status [ PlaceAfter = ResultExecute ]
+{
+	Set tLine = $Piece(qHandle,"^",2)
+	Set tSC = ##class(%Monitor.System.LineByLine).ResultFetch(.qHandle,.Row,.AtEnd)
+	If 'AtEnd {
+		Set tCovered = $Case($ListGet($List(Row,1),1),0:0,"":0,:1)
+		Set Row = $ListBuild(tLine,tCovered)
+	}
+	Quit $$$OK
+}
+
+ClassMethod ResultClose(ByRef qHandle As %Binary) As %Status [ PlaceAfter = ResultExecute ]
+{
+	Quit ##class(%Monitor.System.LineByLine).ResultClose(.qHandle)
+}
+
+}

--- a/src/utcov/Utils.cls
+++ b/src/utcov/Utils.cls
@@ -71,7 +71,8 @@ ClassMethod ConvertToClassCoverage(pTestIndex As %String)
 			While (tResLines.%Next(.tSC)) {
 				$$$ThrowOnError(tSC)
 				Kill tMap
-				$$$ThrowOnError(##class(%Studio.Debugger).SourceLine(tRtnName, tResLines.%Get("LineNumber"), 1, tResLines.%Get("LineNumber"), $Length(..GetLineText(tRtnName,"int",tResLines.%Get("LineNumber"))), $Namespace, .tMap))
+				Set tLineNumber = tResLines.%Get("LineNumber")
+				$$$ThrowOnError(##class(%Studio.Debugger).SourceLine(tRtnName, tLineNumber, 1, tLineNumber, $Length(..GetLineText(tRtnName,"int",tLineNumber)), $Namespace, .tMap))
 				
 				If $Data(tMap("CLS",1),tData1) && $Data(tMap("CLS",2),tData2) {
 					Set $ListBuild(tClass1,tMethod1,tLine1) = tData1
@@ -79,22 +80,22 @@ ClassMethod ConvertToClassCoverage(pTestIndex As %String)
 					If $Data(tMethodMaps(tOther,tMethod1),tMethodOffset) {
 						For tLine = tLine1:1:tLine2 {
 							Set tClassLine = tMethodOffset+1+tLine
-							&sql(update utcov.Data
+							&sql(update utcov.Data D
 								set LineCovered = 1
 								where TestIndex = :pTestIndex
 									and RoutineType = 'cls'
 									and RoutineName = :tClassName
 									and LineNumber = :tClassLine
-									/*and exists (
+									and exists (
 										select top 1 1 from utcov.Data OTHER
 										where OTHER.TestIndex = :pTestIndex
 											and OTHER.RoutineType = 'int'
 											and OTHER.RoutineName = :tRtnName
-											and OTHER.LineNumber = :tRes.%Get("LineNumber")
+											and OTHER.LineNumber = :tLineNumber
 											and OTHER.LineCovered = 1
 											and OTHER.TestClass = D.TestClass
 											and OTHER.TestMethod = D.TestMethod
-									)*/
+									)
 							)
 							If (SQLCODE < 0) {
 								Throw ##class(%Exception.SQL).CreateFromSQLCODE(SQLCODE,%msg)

--- a/test/UnitTest/Main.cls
+++ b/test/UnitTest/Main.cls
@@ -1,10 +1,10 @@
 Class UnitTest.Main
 {
 
-ClassMethod Run()
+ClassMethod Run(pCoverageLevel As %Integer = 0)
 {
 	Do ##class(utcov.Data).%KillExtent()
-	Do ##class(utcov.Manager).RunAllTests("UnitTest",,,$ListBuild("UnitTest.SampleTestedClass","UnitTest.SampleUnitTest"))
+	Do ##class(utcov.Manager).RunAllTests("UnitTest",,,$ListBuild("UnitTest.SampleTestedClass","UnitTest.SampleUnitTest"),,pCoverageLevel)
 }
 
 }

--- a/test/UnitTest/Main.cls
+++ b/test/UnitTest/Main.cls
@@ -1,0 +1,10 @@
+Class UnitTest.Main
+{
+
+ClassMethod Run()
+{
+	Do ##class(utcov.Data).%KillExtent()
+	Do ##class(utcov.Manager).RunAllTests("UnitTest",,,$ListBuild("UnitTest.SampleTestedClass","UnitTest.SampleUnitTest"))
+}
+
+}

--- a/test/UnitTest/SampleTestedClass.cls
+++ b/test/UnitTest/SampleTestedClass.cls
@@ -1,0 +1,9 @@
+Class UnitTest.SampleTestedClass
+{
+
+ClassMethod MyMethod()
+{
+	Write "Hello World",!
+}
+
+}

--- a/test/UnitTest/SampleTestedClass.cls
+++ b/test/UnitTest/SampleTestedClass.cls
@@ -6,4 +6,9 @@ ClassMethod MyMethod()
 	Write "Hello World",!
 }
 
+ClassMethod MyOtherMethod() As %Integer
+{
+	Quit 42
+}
+
 }

--- a/test/UnitTest/SampleUnitTest.cls
+++ b/test/UnitTest/SampleUnitTest.cls
@@ -1,0 +1,10 @@
+Class UnitTest.SampleUnitTest extends %UnitTest.TestCase
+{
+
+Method TestRunTests()
+{
+	Do ##class(UnitTest.SampleTestedClass).MyMethod()
+	Do $$$AssertEquals(1,1,"Test")
+}
+
+}

--- a/test/UnitTest/SampleUnitTest.cls
+++ b/test/UnitTest/SampleUnitTest.cls
@@ -1,10 +1,24 @@
 Class UnitTest.SampleUnitTest extends %UnitTest.TestCase
 {
 
-Method TestRunTests()
+Method Test1()
 {
 	Do ##class(UnitTest.SampleTestedClass).MyMethod()
 	Do $$$AssertEquals(1,1,"Test")
+}
+
+Method Test2()
+{
+	Set tAnswer = ##class(UnitTest.SampleTestedClass).MyOtherMethod()
+	Do $$$AssertEquals(tAnswer,42)
+}
+
+Method TestAll()
+{
+	Do ##class(UnitTest.SampleTestedClass).MyMethod()
+	Do $$$AssertEquals(1,1,"Test")
+	Set tAnswer = ##class(UnitTest.SampleTestedClass).MyOtherMethod()
+	Do $$$AssertEquals(tAnswer,42)
 }
 
 }


### PR DESCRIPTION
I've had a bit of free time and was curious (this is a really interesting idea!), so I've added a few more pieces you can cobble in to your vision for code coverage. These are, in some sense, the trickier parts.

At a basic level: import all the code here, then:
Do ##class(UnitTest.Main).Run(2)

The above method will simulate running a unit test with code coverage tracked for a few particular classes. The code coverage is tracked in the .int code but also mapped back to .cls.

You can then also go to utcov.UI.SimpleResultViewer.cls in your namespace's default web application (typically /csp/<namespace>/ - i.e., /csp/utcov/utcov.UI.SimpleResultViewer.cls for me) to show the code coverage results, filterable by test run / test class / test method.

In terms of using this, you can call in to utcov.Manager with lists of classes similarly to how UnitTest.Main::Run does. The queries in SimpleResultViewer may be useful for drilling down through the results.

There are still a few major challenges I see:
1. Determining if a particular line of code can actually be executed (and therefore if lack of coverage should be a red flag). Some things like comments are obvious. Other things like "Try {" don't ever show up as executed. This really requires COS parsing. This isn't implemented in the pull request, but there's a property for it in the persistent class and 
2. Holes in the .int -> .cls mapping - what we have from %Studio.Debugger is pretty good, but isn't perfect, and would be very difficult to extend.
3. Measuring coverage of generated code and code-generating code. (One option would be to compile classes that do code generation as part of the unit tests, assuming the unit tests use helper classes that are unit test-specific and are intended to exercise all paths of the code generator.)

The persistent class could probably be broken down a bit as well. It's currently all one big table with lots of duplicated data, but doesn't need to be; performance might improve if it's split out into several.

The viewer uses Zen, which was great for throwing it together really quickly. REST APIs providing similar information would be nice in the longer run, especially from the perspective of decoupling UI and back-end if the table structure is to change.

Enjoy!
Tim
